### PR TITLE
feat: add buff effects when keystroke velocity reached

### DIFF
--- a/src/panel/dom.ts
+++ b/src/panel/dom.ts
@@ -3,27 +3,37 @@ export class DOM {
   private _movementContainerSelector: string
   private _transitionContainerSelector: string
   private _transitionSelector: string
+  private _buffContainerSelector: string
+  private _buffSelector: string
 
   private _movementContainerElement: HTMLElement | undefined
   private _petImageElement: HTMLImageElement | undefined
   private _transitionContainerElement: HTMLElement | undefined
   private _transitionImageElement: HTMLImageElement | undefined
+  private _buffContainerElement: HTMLElement | undefined
+  private _buffImageElement: HTMLImageElement | undefined
 
   constructor({
     movementContainerSelector,
     petImageSelector,
     transitionContainerSelector,
     transitionSelector,
+    buffContainerSelector,
+    buffSelector,
   }: {
     petImageSelector: string
     movementContainerSelector: string
     transitionContainerSelector: string
     transitionSelector: string
+    buffContainerSelector: string
+    buffSelector: string
   }) {
     this._petImageSelector = petImageSelector
     this._movementContainerSelector = movementContainerSelector
     this._transitionContainerSelector = transitionContainerSelector
     this._transitionSelector = transitionSelector
+    this._buffContainerSelector = buffContainerSelector
+    this._buffSelector = buffSelector
   }
 
   protected getHTMLElement = <T>(elementName: string): T => {
@@ -69,5 +79,23 @@ export class DOM {
       )
     }
     return this._transitionImageElement
+  }
+
+  getBuffSelector(): HTMLElement {
+    if (!this._buffContainerElement) {
+      this._buffContainerElement = this.getHTMLElement<HTMLElement>(
+        this._buffContainerSelector
+      )
+    }
+    return this._buffContainerElement
+  }
+
+  getBuffImageSelector(): HTMLImageElement {
+    if (!this._buffImageElement) {
+      this._buffImageElement = this.getHTMLElement<HTMLImageElement>(
+        this._buffSelector
+      )
+    }
+    return this._buffImageElement
   }
 }

--- a/src/panel/index.ts
+++ b/src/panel/index.ts
@@ -21,12 +21,14 @@ import {
   NextFrameFn,
   NextFrameFnReturn,
   Transforms,
-  PetAnimation,
+  Animation,
   PetLevel,
   State,
+  ContextTransform,
 } from './types'
 import { DOM } from './dom'
 import { state, initializeState, setState } from './state'
+import { KeyStrokeVelocity } from './keystroke-velocity'
 
 export {
   petTypes,
@@ -48,12 +50,14 @@ export {
   NextFrameFn,
   NextFrameFnReturn,
   Transforms,
-  PetAnimation,
+  Animation,
   PetLevel,
   State,
+  ContextTransform,
   initializeState,
   state,
   setState,
   transforms,
   DOM,
+  KeyStrokeVelocity,
 }

--- a/src/panel/keystroke-velocity.ts
+++ b/src/panel/keystroke-velocity.ts
@@ -1,4 +1,4 @@
-export class Xp {
+export class KeyStrokeVelocity {
   _periods: number
   _msPerPeriod: number
   _intervalId: NodeJS.Timeout | undefined = undefined
@@ -7,18 +7,37 @@ export class Xp {
   _currentPeriodKeystrokes = 0
   _velocity = 0
   _multiplier = 0
+  _threshold = 0
 
   getMultipler() {
     return this._multiplier
   }
 
-  constructor(periods: number = 6, msPerPeriod: number = 10000) {
+  constructor(
+    periods: number = 6,
+    msPerPeriod: number = 10_000,
+    threshold: number = 5
+  ) {
     this._periods = periods
     this._msPerPeriod = msPerPeriod
+    this._threshold = threshold
+    return this
   }
 
-  onKeyPress() {
+  reset() {
+    this._velocity = 0
+    this._multiplier = 0
+  }
+
+  addKeyPress() {
+    if (!this._intervalId) {
+      return
+    }
     this._currentPeriodKeystrokes++
+  }
+
+  isThresholdExceeded() {
+    return this._multiplier >= this._threshold
   }
 
   startWatch() {

--- a/src/panel/pets.ts
+++ b/src/panel/pets.ts
@@ -3,16 +3,18 @@ import {
   Pet,
   UserPetArgs,
   Direction,
-  PetAnimation,
+  Animation,
   UserPet,
   PetLevel,
   Gifs,
+  ContextTransform,
 } from './'
 
 export const gifs: Gifs = {
   egg1: 'egg1.gif',
   dust1: 'dust1.gif',
   dust2: 'dust2.gif',
+  buff1: 'buff1.gif',
   monster1phase1: 'm1d1.gif',
   monster1phase2: 'm1d2.gif',
   monster1phase3: 'm1d3.gif',
@@ -58,6 +60,7 @@ const animationDefaults = {
   height: 64,
   speed: 0,
   offset: 0,
+  isFixedPosition: true,
 }
 
 const egg: PetLevel = {
@@ -79,12 +82,22 @@ const egg: PetLevel = {
 }
 
 // Generic evolution transition
-const transition: PetAnimation = {
+const transition: Animation = {
   ...animationDefaults,
   gif: 'dust2',
   offset: -80,
   width: 280,
   height: 100,
+}
+
+const contextTransforms = {
+  reverseDirectionTransform: (offset: number) =>
+    (({ userPetContext }: { userPetContext: UserPet }) =>
+      userPetContext.direction === Direction.left
+        ? {
+            offset,
+          }
+        : {}) as ContextTransform,
 }
 
 export const petTypes = new Map<string, Pet>([
@@ -96,7 +109,7 @@ export const petTypes = new Map<string, Pet>([
         [
           1,
           {
-            xp: 35,
+            xp: 10,
             defaultState: 'walking',
             animations: {
               transition,
@@ -105,13 +118,17 @@ export const petTypes = new Map<string, Pet>([
                 gif: 'monster1phase1',
                 speed: 4,
               },
+              buff: {
+                ...animationDefaults,
+                gif: 'buff1',
+              },
             },
           },
         ],
         [
           2,
           {
-            xp: 150000,
+            xp: 20,
             defaultState: 'walking',
             animations: {
               transition,
@@ -120,13 +137,19 @@ export const petTypes = new Map<string, Pet>([
                 gif: 'monster1phase2',
                 speed: 3,
               },
+              buff: {
+                ...animationDefaults,
+                gif: 'buff1',
+                height: 90,
+                width: 90,
+              },
             },
           },
         ],
         [
           3,
           {
-            xp: 240000,
+            xp: 30,
             defaultState: 'walking',
             animations: {
               transition,
@@ -135,61 +158,15 @@ export const petTypes = new Map<string, Pet>([
                 gif: 'monster1phase3',
                 speed: 3,
               },
-            },
-          },
-        ],
-      ]),
-    },
-  ],
-  [
-    'monster2',
-    {
-      levels: new Map([
-        [0, egg],
-        [
-          1,
-          {
-            xp: 35,
-            defaultState: 'walking',
-            animations: {
-              transition,
-              walking: {
+              buff: {
                 ...animationDefaults,
-                gif: 'monster2phase1',
-                width: 64,
-                speed: 3,
-              },
-            },
-          },
-        ],
-        [
-          2,
-          {
-            xp: 100000,
-            defaultState: 'walking',
-            animations: {
-              transition,
-              walking: {
-                ...animationDefaults,
-                gif: 'monster2phase2',
-                width: 64,
-                speed: 3,
-              },
-            },
-          },
-        ],
-        [
-          3,
-          {
-            xp: 600000,
-            defaultState: 'walking',
-            animations: {
-              transition,
-              walking: {
-                ...animationDefaults,
-                gif: 'monster2phase3',
-                width: 64,
-                speed: 3,
+                gif: 'buff1',
+                width: 100,
+                height: 100,
+                isFixedPosition: false,
+                contextTransforms: [
+                  contextTransforms.reverseDirectionTransform(-20),
+                ],
               },
             },
           },
@@ -197,118 +174,178 @@ export const petTypes = new Map<string, Pet>([
       ]),
     },
   ],
-  [
-    'monster3',
-    {
-      levels: new Map([
-        [0, egg],
-        [
-          1,
-          {
-            xp: 35,
-            defaultState: 'walking',
-            animations: {
-              transition,
-              walking: {
-                ...animationDefaults,
-                gif: 'monster3phase1',
-                width: 64,
-                speed: 1,
-              },
-            },
-          },
-        ],
-        [
-          2,
-          {
-            xp: 599900,
-            defaultState: 'walking',
-            animations: {
-              transition,
-              walking: {
-                ...animationDefaults,
-                gif: 'monster3phase2',
-                width: 64,
-                speed: 0,
-              },
-            },
-          },
-        ],
-        [
-          3,
-          {
-            xp: 600000,
-            defaultState: 'walking',
-            animations: {
-              transition,
-              walking: {
-                ...animationDefaults,
-                gif: 'monster3phase3',
-                width: 64,
-                speed: 2,
-              },
-            },
-          },
-        ],
-      ]),
-    },
-  ],
-  [
-    'monster4',
-    {
-      levels: new Map([
-        [0, egg],
-        [
-          1,
-          {
-            xp: 35,
-            defaultState: 'walking',
-            animations: {
-              transition,
-              walking: {
-                ...animationDefaults,
-                gif: 'monster4phase1',
-                width: 64,
-                speed: 3,
-              },
-            },
-          },
-        ],
-        [
-          2,
-          {
-            xp: 150000,
-            defaultState: 'walking',
-            animations: {
-              transition,
-              walking: {
-                ...animationDefaults,
-                gif: 'monster4phase2',
-                width: 64,
-                speed: 3,
-              },
-            },
-          },
-        ],
-        [
-          3,
-          {
-            xp: 240000,
-            defaultState: 'walking',
-            animations: {
-              transition,
-              walking: {
-                ...animationDefaults,
-                gif: 'monster4phase3',
-                width: 64,
-                speed: 4,
-              },
-            },
-          },
-        ],
-      ]),
-    },
-  ],
+  // [
+  //   'monster2',
+  //   {
+  //     levels: new Map([
+  //       [0, egg],
+  //       [
+  //         1,
+  //         {
+  //           xp: 10,
+  //           defaultState: 'walking',
+  //           animations: {
+  //             transition,
+  //             walking: {
+  //               ...animationDefaults,
+  //               gif: 'monster2phase1',
+  //               width: 64,
+  //               speed: 3,
+  //             },
+  //             buff: {
+  //               ...animationDefaults,
+  //               gif: 'buff1',
+  //             },
+  //           },
+  //         },
+  //       ],
+  //       [
+  //         2,
+  //         {
+  //           xp: 20,
+  //           defaultState: 'walking',
+  //           animations: {
+  //             transition,
+  //             walking: {
+  //               ...animationDefaults,
+  //               gif: 'monster2phase2',
+  //               width: 64,
+  //               speed: 3,
+  //             },
+  //           },
+  //         },
+  //       ],
+  //       [
+  //         3,
+  //         {
+  //           xp: 30,
+  //           defaultState: 'walking',
+  //           animations: {
+  //             transition,
+  //             walking: {
+  //               ...animationDefaults,
+  //               gif: 'monster2phase3',
+  //               width: 64,
+  //               speed: 3,
+  //             },
+  //           },
+  //         },
+  //       ],
+  //     ]),
+  //   },
+  // ],
+  // [
+  //   'monster3',
+  //   {
+  //     levels: new Map([
+  //       [0, egg],
+  //       [
+  //         1,
+  //         {
+  //           xp: 10,
+  //           defaultState: 'walking',
+  //           animations: {
+  //             transition,
+  //             walking: {
+  //               ...animationDefaults,
+  //               gif: 'monster3phase1',
+  //               width: 64,
+  //               speed: 1,
+  //             },
+  //           },
+  //         },
+  //       ],
+  //       [
+  //         2,
+  //         {
+  //           xp: 20,
+  //           defaultState: 'walking',
+  //           animations: {
+  //             transition,
+  //             walking: {
+  //               ...animationDefaults,
+  //               gif: 'monster3phase2',
+  //               width: 64,
+  //               speed: 0,
+  //             },
+  //           },
+  //         },
+  //       ],
+  //       [
+  //         3,
+  //         {
+  //           xp: 30,
+  //           defaultState: 'walking',
+  //           animations: {
+  //             transition,
+  //             walking: {
+  //               ...animationDefaults,
+  //               gif: 'monster3phase3',
+  //               width: 64,
+  //               speed: 2,
+  //             },
+  //           },
+  //         },
+  //       ],
+  //     ]),
+  //   },
+  // ],
+  // [
+  //   'monster4',
+  //   {
+  //     levels: new Map([
+  //       [0, egg],
+  //       [
+  //         1,
+  //         {
+  //           xp: 10,
+  //           defaultState: 'walking',
+  //           animations: {
+  //             transition,
+  //             walking: {
+  //               ...animationDefaults,
+  //               gif: 'monster4phase1',
+  //               width: 64,
+  //               speed: 3,
+  //             },
+  //           },
+  //         },
+  //       ],
+  //       [
+  //         2,
+  //         {
+  //           xp: 20,
+  //           defaultState: 'walking',
+  //           animations: {
+  //             transition,
+  //             walking: {
+  //               ...animationDefaults,
+  //               gif: 'monster4phase2',
+  //               width: 64,
+  //               speed: 3,
+  //             },
+  //           },
+  //         },
+  //       ],
+  //       [
+  //         3,
+  //         {
+  //           xp: 30,
+  //           defaultState: 'walking',
+  //           animations: {
+  //             transition,
+  //             walking: {
+  //               ...animationDefaults,
+  //               gif: 'monster4phase3',
+  //               width: 64,
+  //               speed: 4,
+  //             },
+  //           },
+  //         },
+  //       ],
+  //     ]),
+  //   },
+  // ],
 ])
 
 export const randomPetType = (): PetType =>
@@ -326,8 +363,9 @@ export const getPetAnimations = ({
 }: {
   userPet: UserPet
 }): {
-  animation: PetAnimation
-  transition: PetAnimation | undefined
+  pet: Animation
+  transition: Animation | undefined
+  buff: Animation | undefined
 } => {
   const petTypeFound = petTypes.get(userPet.type)
   if (!petTypeFound) {
@@ -352,9 +390,13 @@ export const getPetAnimations = ({
       ? levelFound.animations.transition
       : undefined
 
+  const buff =
+    'buff' in levelFound.animations ? levelFound.animations.buff : undefined
+
   return {
-    animation: levelFound.animations[userPet.state],
+    pet: levelFound.animations[userPet.state],
     transition,
+    buff,
   }
 }
 
@@ -369,6 +411,8 @@ export const generatePet = ({ name, type }: UserPetArgs): UserPet => ({
   isTransitionIn: true,
   name,
   type,
+  buffCountdownTimerMs: 0,
+  isApplyBuff: false,
 })
 
 export const getLevel = ({

--- a/src/panel/types.ts
+++ b/src/panel/types.ts
@@ -8,20 +8,31 @@ export type Gifs = { [name: string]: string }
 
 export type PetState = 'walking' | 'idle' | 'transition'
 
-export type PetAnimation = {
+// Special transformations which apply in certain context,
+// i.e., a buff animation's offset may change slightly based on
+// pet's direction
+export type ContextTransformProps = {
+  [transformProp: string]: string | number
+}
+
+export type ContextTransform = (contextInput: any) => ContextTransformProps
+
+export type Animation = {
   gif: string
-  width: number
-  height: number
+  width?: number
+  height?: number
   offset?: number
   speed?: number
   duration?: number
+  isFixedPosition?: boolean
+  contextTransforms?: ContextTransform[]
 }
 
 export type PetLevel = {
   xp: number
   defaultState: PetState
   animations: {
-    [name: string]: PetAnimation
+    [name: string]: Animation
   }
 }
 
@@ -37,6 +48,8 @@ export interface UserPetBaseProps {
   xp: number
   state: PetState
   isTransitionIn: boolean
+  isApplyBuff: boolean
+  buffCountdownTimerMs: number
 }
 
 export type PetType = 'monster1' | 'monster2' | 'unknown'


### PR DESCRIPTION
- Add buff effects to pets.
- Effects are activated when a rate of keystrokes ("keystroke velocity") is achieved.
- Still in draft (buff effects require scaling per character)

![197284710-1e8c102b-b6d2-4a83-ac4a-d035e72d611a](https://github.com/blairjordan/codachi/assets/998930/81621548-135e-447f-bc92-14678e4e291c)

- Original issue: https://github.com/blairjordan/codachi/issues/4